### PR TITLE
Improve manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,10 +3,10 @@
     "id": "fluxbb",
     "packaging_format": 1,
     "description": {
-        "en": "FluxBB is fast, light, user-friendly forum software for your website.",
-        "fr": "FluxBB est un forum de discussions écrit en PHP rapide et léger."
+        "en": "A fast, light, user-friendly forum software",
+        "fr": "Un forum de discussions rapide et léger."
     },
-    "version": "1.5.11",
+    "version": "1.5.11~ynh1",
     "url": "https://fluxbb.org/",
     "license": "GPL-2.0-only",
     "maintainer": {


### PR DESCRIPTION
Small tweak to manifest, in particular to use the version format standard ...

Note that there's also a second major issue in package_linter about using php-fpm.ini files 

> ✘ Using a separate php-fpm.ini file is deprecated. Please merge your php-fpm directives directly in the pool file. (c.f. https://github.com/YunoHost-Apps/nextcloud_ynh/issues/138 ) 

which will soon trigger a downgrade to level 4 if this isn't fixed ...